### PR TITLE
Make aws-sdk optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "CPU"
   ],
   "dependencies": {
-    "aws-sdk": "~2.1.30",
     "q": "~1.4.1",
     "request": "^2.55.0"
+  },
+  "optionalDependencies": {
+    "aws-sdk": "~2.1.30"
   },
   "devDependencies": {
     "mocha": "~2.2.5",


### PR DESCRIPTION
The reason for this is in case you choose to use this package in a Lambda function (ie. [your gist](https://gist.github.com/jeka-kiselyov/3f3801a165cab9e4a9fd)), the package can just use the version that is pre-install on the Lambda machine.

By default, nothing changes when a user does `npm install aws-cloudwatch-chart`, the magic happens when they user installs with the `no-optionals` option: `npm install aws-cloudwatch-chart --no-optionals`
